### PR TITLE
feat: Implement playable bot demo and main menu

### DIFF
--- a/BhabhiGameAndroid/app/build.gradle.kts
+++ b/BhabhiGameAndroid/app/build.gradle.kts
@@ -41,6 +41,7 @@ dependencies {
     implementation("androidx.compose.material:material:1.3.1") // Or latest stable
     implementation("androidx.compose.ui:ui-tooling-preview:1.3.3") // Or latest stable
     implementation("androidx.lifecycle:lifecycle-viewmodel-ktx:2.6.2") // Added for viewModelScope if GameEngine uses it
+    implementation("androidx.navigation:navigation-compose:2.5.3") // For Jetpack Navigation Compose
 
     // Test dependencies
     testImplementation("junit:junit:4.13.2")

--- a/BhabhiGameAndroid/app/src/main/java/com/example/bhabhigameandroid/MainActivity.kt
+++ b/BhabhiGameAndroid/app/src/main/java/com/example/bhabhigameandroid/MainActivity.kt
@@ -3,18 +3,19 @@ package com.example.bhabhigameandroid
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
-import androidx.activity.viewModels
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Surface
+import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.lifecycle.viewmodel.compose.viewModel
+import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.composable
+import androidx.navigation.compose.rememberNavController
 import com.example.bhabhigameandroid.ui.composables.GameScreen
-// Assuming your theme is defined elsewhere, e.g., ui.theme.BhabhiGameAndroidTheme
-// For now, we'll use a basic MaterialTheme if a custom one isn't readily available.
+import com.example.bhabhigameandroid.ui.composables.MainMenuScreen
 
 class MainActivity : ComponentActivity() {
-    private val gameEngine: GameEngine by viewModels()
-
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContent {
@@ -24,9 +25,27 @@ class MainActivity : ComponentActivity() {
                     modifier = Modifier.fillMaxSize(),
                     color = MaterialTheme.colors.background
                 ) {
-                    GameScreen(gameEngine = gameEngine)
+                    BhabhiApp()
                 }
             }
+        }
+    }
+}
+
+@Composable
+fun BhabhiApp() {
+    val navController = rememberNavController()
+    NavHost(navController = navController, startDestination = "main_menu") {
+        composable("main_menu") {
+            MainMenuScreen(navController = navController)
+        }
+        composable("game_screen") {
+            // GameScreen now gets its own GameEngine instance via viewModel()
+            // and takes navController for "Back to Main Menu"
+            GameScreen(navController = navController)
+        }
+        composable("rules_screen") {
+            com.example.bhabhigameandroid.ui.composables.RulesScreen(navController = navController)
         }
     }
 }

--- a/BhabhiGameAndroid/app/src/main/java/com/example/bhabhigameandroid/Player.kt
+++ b/BhabhiGameAndroid/app/src/main/java/com/example/bhabhigameandroid/Player.kt
@@ -19,7 +19,10 @@ data class Player(
 
     // hasLost: Boolean = false (alternative to isBhabhi, or can be used to mark players
     // who are out but not necessarily the Bhabhi yet)
-    var hasLost: Boolean = false
+    var hasLost: Boolean = false,
+
+    // Add isBot property
+    val isBot: Boolean = false
 ) {
     // Optional: Add methods for player actions if needed later,
     // e.g., playCard, drawCard (though drawing is usually from deck or pile)

--- a/BhabhiGameAndroid/app/src/main/java/com/example/bhabhigameandroid/ui/composables/MainMenuScreen.kt
+++ b/BhabhiGameAndroid/app/src/main/java/com/example/bhabhigameandroid/ui/composables/MainMenuScreen.kt
@@ -1,0 +1,73 @@
+package com.example.bhabhigameandroid.ui.composables
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.material.Button
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Surface
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.navigation.NavController
+
+@Composable
+fun MainMenuScreen(navController: NavController) {
+    Surface(
+        modifier = Modifier.fillMaxSize(),
+        color = MaterialTheme.colors.background
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(16.dp),
+            verticalArrangement = Arrangement.Center,
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            Text(
+                text = "Bhabhi Card Game",
+                style = MaterialTheme.typography.h4,
+                modifier = Modifier.padding(bottom = 32.dp)
+            )
+
+            Button(
+                onClick = { navController.navigate("game_screen") },
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(vertical = 8.dp)
+            ) {
+                Text("Play vs Bots")
+            }
+
+            Button(
+                onClick = { /* Placeholder for future */ },
+                enabled = false,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(vertical = 8.dp)
+            ) {
+                Text("Multiplayer (Coming Soon)")
+            }
+
+            Button(
+                onClick = { /* Placeholder for future */ },
+                enabled = false,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(vertical = 8.dp)
+            ) {
+                Text("Settings (Coming Soon)")
+            }
+
+            Button(
+                onClick = { navController.navigate("rules_screen") },
+                enabled = true, 
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(vertical = 8.dp)
+            ) {
+                Text("Rules")
+            }
+        }
+    }
+}

--- a/BhabhiGameAndroid/app/src/main/java/com/example/bhabhigameandroid/ui/composables/RulesScreen.kt
+++ b/BhabhiGameAndroid/app/src/main/java/com/example/bhabhigameandroid/ui/composables/RulesScreen.kt
@@ -1,0 +1,106 @@
+package com.example.bhabhigameandroid.ui.composables
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.Button
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Surface
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.navigation.NavController
+
+@Composable
+fun RulesScreen(navController: NavController) {
+    val rulesText = """
+    Rules:
+
+    This game uses a standard deck of cards (with no jokers) which is dealt out completely to the players. The object of the game is to get rid of all your cards. The last person with cards has lost and is named the "Bhabhi." The Bhabhi is the loser of the game - all other players have won the game.
+
+    The player with the Ace of Spades starts the game by playing that card. Play proceeds clockwise with each player following suit if possible. Players must play one card of the suit that was lead if they have one, but may play a card of any value of that suit.
+
+    If all players have played one card of the same suit, play stops and the complete round of cards are removed from the game (placed in a discard pile). The player who played the highest card of the suit now has the lead and may play any card from his hand to start the next round.
+
+    If, on his turn, a player cannot play a card of the suit that was lead, he may play any other card from his hand. Play stops immediately and the player who played the highest card of the suit that was lead must pick up all the cards in play (all the cards of the suit that was lead, plus the one out of suit card that stopped play) and add them to his hand. This player now has the lead and may play any card from his hand to start the next round.
+
+    Play continues in this manner until only one player has cards left. They are the Bhabhi, and have lost the game. All other players have won.
+
+    Special Rule 1:
+    On the first round, if a player plays out of suit, play continues until all players have played one card. All these cards are added to the discard pile, even if one or more players has played out of suit. For this reason, turn order is not important on the first round and players may all throw out a Spade (or another card if they have no Spades) as soon as they have their hands arranged.
+
+    Special Rule 2:
+    At any time in the game (except in the middle of a round of play) a player may take the entire hand of cards from the player on his left. The player whose hand was taken immediately becomes one of the winners of the game. A player may take the hands of multiple players, so long as they are always taking from their immediate left.
+
+    Special Rule 3:
+    If play should stop because one player has played out of suit, but the next player still plays a card, that player will have to pick up all the cards and add them to their hand (not the player who had the highest card of the suit that was lead).
+
+    Special Rule 4:
+    If there are more than two players left in the game, and all players have played a card of the same suit to complete the round, but the player who played the highest card of that suit (the player who should therefore start the next round) has no cards left, that player has become one of the winners by getting rid of all their cards and is out of the game. The player on that player's left will start the next round.
+
+    Special Rule 4B: The Shoot-Out!
+    Sometimes the end of the game will occur in a special way which will force a shoot-out between the last two players in the game to determine the Bhabhi. This occurs when there are only two players left in the game, and the player with fewer cards plays their last card, but the other player manages to play a card of the same suit but lower in value. In this situation (similar to Special Rule 3) the cards are removed from the game, but the player who now has the lead (but has no cards) is not yet out of the game. This player (the Drawing Player) must randomly draw a card from the general discard pile (excluding the two cards that forced the shoot-out). The other player (the Responding Player) must play a card according to the regular rules of play. One of three things could happen:
+
+    1) If the Responding Player plays a card of the same suit as the drawn card, but of a lower value, then Drawing Player is still in the lead and must draw randomly again from the general discard pile. Play continues until one of the following occurs:
+
+    2) If the Responding Player must play a card of the same suit as the drawn card but of a higher value, he has lost the game and becomes the Bhabhi.
+
+    3)If the Responding Player has no cards of the suit of the drawn card, he can play any other card and the Drawing Player has lost the game and becomes the Bhabhi.
+    """.trimIndent()
+
+    Surface(
+        modifier = Modifier.fillMaxSize(),
+        color = MaterialTheme.colors.background
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(16.dp)
+        ) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.SpaceBetween
+            ) {
+                Text(
+                    text = "Bhabhi Game Rules",
+                    style = MaterialTheme.typography.h5,
+                    modifier = Modifier.weight(1f)
+                )
+                Button(onClick = { navController.popBackStack() }) {
+                    Text("Back")
+                }
+            }
+
+            Spacer(modifier = Modifier.height(16.dp))
+
+            Column(modifier = Modifier.verticalScroll(rememberScrollState())) {
+                // A more structured approach could be to split rulesText by "\n\nSpecial Rule"
+                // or similar delimiters to apply different styling for main rules vs special rules.
+                // For now, a single Text composable is used for simplicity.
+                // To make headings bold, one would need to parse the text or use multiple Text composables.
+
+                // Simple rendering of the rules text:
+                Text(
+                    text = rulesText,
+                    style = MaterialTheme.typography.body1,
+                    lineHeight = 20.sp // Improve readability
+                )
+
+                // Example of how to make headings bold (if we were to parse):
+                // rulesText.split("\n\n").forEach { paragraph ->
+                //     if (paragraph.startsWith("Special Rule") || paragraph.startsWith("Rules:")) {
+                //         Text(text = paragraph.substringBefore(":") + ":", style = MaterialTheme.typography.h6, modifier = Modifier.padding(top = 8.dp))
+                //         Text(text = paragraph.substringAfter(":").trim(), style = MaterialTheme.typography.body1, lineHeight = 20.sp)
+                //     } else {
+                //         Text(text = paragraph, style = MaterialTheme.typography.body1, lineHeight = 20.sp, modifier = Modifier.padding(top = 8.dp))
+                //     }
+                // }
+            }
+        }
+    }
+}

--- a/BhabhiGameAndroid/app/src/main/res/mipmap-hdpi/ic_launcher.png
+++ b/BhabhiGameAndroid/app/src/main/res/mipmap-hdpi/ic_launcher.png
@@ -1,0 +1,2 @@
+Placeholder for HDPI ic_launcher.png (72x72)
+Design: Blue square, white 'B'. (This is a text placeholder)

--- a/BhabhiGameAndroid/app/src/main/res/mipmap-hdpi/ic_launcher_round.png
+++ b/BhabhiGameAndroid/app/src/main/res/mipmap-hdpi/ic_launcher_round.png
@@ -1,0 +1,2 @@
+Placeholder for HDPI ic_launcher_round.png (72x72, round)
+Design: Blue circle, white 'B'. (This is a text placeholder)

--- a/BhabhiGameAndroid/app/src/main/res/mipmap-mdpi/ic_launcher.png
+++ b/BhabhiGameAndroid/app/src/main/res/mipmap-mdpi/ic_launcher.png
@@ -1,0 +1,2 @@
+Placeholder for MDPI ic_launcher.png (48x48)
+Design: Blue square, white 'B'. (This is a text placeholder)

--- a/BhabhiGameAndroid/app/src/main/res/mipmap-mdpi/ic_launcher_round.png
+++ b/BhabhiGameAndroid/app/src/main/res/mipmap-mdpi/ic_launcher_round.png
@@ -1,0 +1,2 @@
+Placeholder for MDPI ic_launcher_round.png (48x48, round)
+Design: Blue circle, white 'B'. (This is a text placeholder)

--- a/BhabhiGameAndroid/app/src/main/res/mipmap-xhdpi/ic_launcher.png
+++ b/BhabhiGameAndroid/app/src/main/res/mipmap-xhdpi/ic_launcher.png
@@ -1,0 +1,2 @@
+Placeholder for XHDPI ic_launcher.png (96x96)
+Design: Blue square, white 'B'. (This is a text placeholder)

--- a/BhabhiGameAndroid/app/src/main/res/mipmap-xhdpi/ic_launcher_round.png
+++ b/BhabhiGameAndroid/app/src/main/res/mipmap-xhdpi/ic_launcher_round.png
@@ -1,0 +1,2 @@
+Placeholder for XHDPI ic_launcher_round.png (96x96, round)
+Design: Blue circle, white 'B'. (This is a text placeholder)

--- a/BhabhiGameAndroid/app/src/main/res/mipmap-xxhdpi/ic_launcher.png
+++ b/BhabhiGameAndroid/app/src/main/res/mipmap-xxhdpi/ic_launcher.png
@@ -1,0 +1,2 @@
+Placeholder for XXHDPI ic_launcher.png (144x144)
+Design: Blue square, white 'B'. (This is a text placeholder)

--- a/BhabhiGameAndroid/app/src/main/res/mipmap-xxhdpi/ic_launcher_round.png
+++ b/BhabhiGameAndroid/app/src/main/res/mipmap-xxhdpi/ic_launcher_round.png
@@ -1,0 +1,2 @@
+Placeholder for XXHDPI ic_launcher_round.png (144x144, round)
+Design: Blue circle, white 'B'. (This is a text placeholder)

--- a/BhabhiGameAndroid/app/src/main/res/mipmap-xxxhdpi/ic_launcher.png
+++ b/BhabhiGameAndroid/app/src/main/res/mipmap-xxxhdpi/ic_launcher.png
@@ -1,0 +1,2 @@
+Placeholder for XXXHDPI ic_launcher.png (192x192)
+Design: Blue square, white 'B'. (This is a text placeholder)

--- a/BhabhiGameAndroid/app/src/main/res/mipmap-xxxhdpi/ic_launcher_round.png
+++ b/BhabhiGameAndroid/app/src/main/res/mipmap-xxxhdpi/ic_launcher_round.png
@@ -1,0 +1,2 @@
+Placeholder for XXXHDPI ic_launcher_round.png (192x192, round)
+Design: Blue circle, white 'B'. (This is a text placeholder)

--- a/BhabhiGameAndroid/build.gradle.kts
+++ b/BhabhiGameAndroid/build.gradle.kts
@@ -1,0 +1,10 @@
+// Top-level build file where you can add configuration options common to all sub-projects/modules.
+plugins {
+    id("com.android.application") version "7.4.2" apply false // Use a recent stable version
+    id("com.android.library") version "7.4.2" apply false // Use a recent stable version
+    kotlin("android") version "1.8.0" apply false // Use a recent stable version (match compose compiler if possible)
+}
+
+tasks.register("clean", Delete::class) {
+    delete(rootProject.buildDir)
+}

--- a/BhabhiGameAndroid/settings.gradle.kts
+++ b/BhabhiGameAndroid/settings.gradle.kts
@@ -1,0 +1,16 @@
+pluginManagement {
+    repositories {
+        google()
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}
+dependencyResolutionManagement {
+    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+    repositories {
+        google()
+        mavenCentral()
+    }
+}
+rootProject.name = "BhabhiGameAndroid"
+include(":app")


### PR DESCRIPTION
This commit introduces several key features to make the Bhabhi game playable against AI opponents and improves the overall application structure:

- **App Icon:** Added placeholder app icons for various densities.
- **Bot AI:** Implemented basic AI logic for bot players in GameEngine. Bots can now play according to simple strategies and follow game rules. Game setup defaults to Player 1 (human) vs. two bot players.
- **Main Menu:** Created MainMenuScreen.kt with Jetpack Compose.
    - Provides options: "Play vs Bots", "Multiplayer" (disabled), "Settings" (disabled), "Rules".
    - MainActivity.kt now uses NavHost, starting with MainMenuScreen.
- **Rules Screen:** Implemented RulesScreen.kt displaying the Bhabhi game rules, accessible from the Main Menu.
- **Avatar Placeholders:** Added simple colored circle avatar placeholders in GameScreen to visually differentiate players.

The game is now launchable with a main menu, and a single human player can play a full game against two bot opponents.