### PR TITLE
chore: Add Gradle Wrapper and update Gradle/Kotlin versions

### DIFF
--- a/BhabhiGameAndroid/app/build.gradle.kts
+++ b/BhabhiGameAndroid/app/build.gradle.kts
@@ -4,11 +4,11 @@ plugins {
 }
 
 android {
-    compileSdk = 33 // Or latest stable
+    compileSdk = 34
     defaultConfig {
         applicationId = "com.example.bhabhigameandroid"
         minSdk = 21
-        targetSdk = 33
+        targetSdk = 34
         versionCode = 1
         versionName = "1.0"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
@@ -30,24 +30,24 @@ android {
         compose = true // Enable Jetpack Compose
     }
     composeOptions {
-        kotlinCompilerExtensionVersion = "1.3.2" // Use a recent stable version
+        kotlinCompilerExtensionVersion = "1.5.3" 
     }
 }
 
 dependencies {
-    implementation("androidx.core:core-ktx:1.9.0") // Or latest stable
-    implementation("androidx.activity:activity-compose:1.6.1") // Or latest stable
-    implementation("androidx.compose.ui:ui:1.3.3") // Or latest stable
-    implementation("androidx.compose.material:material:1.3.1") // Or latest stable
-    implementation("androidx.compose.ui:ui-tooling-preview:1.3.3") // Or latest stable
-    implementation("androidx.lifecycle:lifecycle-viewmodel-ktx:2.6.2") // Added for viewModelScope if GameEngine uses it
-    implementation("androidx.navigation:navigation-compose:2.5.3") // For Jetpack Navigation Compose
+    implementation("androidx.core:core-ktx:1.12.0") 
+    implementation("androidx.activity:activity-compose:1.8.0") 
+    implementation("androidx.compose.ui:ui:1.5.4") 
+    implementation("androidx.compose.material:material:1.5.4") 
+    implementation("androidx.compose.ui:ui-tooling-preview:1.5.4") 
+    implementation("androidx.lifecycle:lifecycle-viewmodel-ktx:2.6.2") 
+    implementation("androidx.navigation:navigation-compose:2.7.5") // Updated to a more recent stable version
 
     // Test dependencies
     testImplementation("junit:junit:4.13.2")
-    testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.7.1") // For testing coroutines and StateFlow
+    testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.7.3") // Updated to a more recent stable version
     androidTestImplementation("androidx.test.ext:junit:1.1.5")
     androidTestImplementation("androidx.test.espresso:espresso-core:3.5.1")
-    androidTestImplementation("androidx.compose.ui:ui-test-junit4:1.3.3")
-    debugImplementation("androidx.compose.ui:ui-tooling:1.3.3")
+    androidTestImplementation("androidx.compose.ui:ui-test-junit4:1.5.4")
+    debugImplementation("androidx.compose.ui:ui-tooling:1.5.4")
 }

--- a/BhabhiGameAndroid/build.gradle.kts
+++ b/BhabhiGameAndroid/build.gradle.kts
@@ -1,8 +1,8 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
-    id("com.android.application") version "7.4.2" apply false // Use a recent stable version
-    id("com.android.library") version "7.4.2" apply false // Use a recent stable version
-    kotlin("android") version "1.8.0" apply false // Use a recent stable version (match compose compiler if possible)
+    id("com.android.application") version "8.1.1" apply false
+    id("com.android.library") version "8.1.1" apply false
+    kotlin("android") version "1.9.10" apply false
 }
 
 tasks.register("clean", Delete::class) {

--- a/BhabhiGameAndroid/gradle/wrapper/gradle-wrapper.properties
+++ b/BhabhiGameAndroid/gradle/wrapper/gradle-wrapper.properties
@@ -1,0 +1,5 @@
+distributionBase=GRADLE_USER_HOME
+distributionPath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.2-bin.zip
+zipStoreBase=GRADLE_USER_HOME
+zipStorePath=wrapper/dists

--- a/BhabhiGameAndroid/gradlew
+++ b/BhabhiGameAndroid/gradlew
@@ -1,0 +1,53 @@
+#!/usr/bin/env sh
+
+#
+# Copyright 2015 the original author or authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Define JVM options here if you want to override the defaults
+# DEFAULT_JVM_OPTS='"-Xmx64m" "-Xms64m"'
+# APP_NAME is the name of the script as invoked.
+# APP_BASE_NAME is the basename of the script.
+# APP_HOME is the home directory of the script.
+# APP_ARGS are the arguments passed to the script.
+
+# Use a simple pattern to find an executable `java` binary in the PATH
+# If not found, then try to use JAVA_HOME
+if [ -n "$JAVA_HOME" ] && [ -x "$JAVA_HOME/bin/java" ]; then
+    JAVACMD="$JAVA_HOME/bin/java"
+else
+    JAVACMD="java"
+fi
+
+if ! "$JAVACMD" -version >/dev/null 2>&1; then
+    echo "ERROR: Cannot find \`java\` binary. Please set JAVA_HOME properly or add \`java\` to your PATH." >&2
+    exit 1
+fi
+
+# Determine the directory where this script resides
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+
+# Define the location of the Gradle Wrapper JAR
+GRADLE_WRAPPER_JAR="$SCRIPT_DIR/gradle/wrapper/gradle-wrapper.jar"
+
+# Construct the classpath for the Gradle Wrapper
+CLASSPATH="$GRADLE_WRAPPER_JAR"
+
+# Execute the Gradle Wrapper
+exec "$JAVACMD" \
+    "${DEFAULT_JVM_OPTS[@]}" \
+    -classpath "$CLASSPATH" \
+    org.gradle.wrapper.GradleWrapperMain \
+    "$@"

--- a/BhabhiGameAndroid/gradlew.bat
+++ b/BhabhiGameAndroid/gradlew.bat
@@ -1,0 +1,84 @@
+@if "%DEBUG%" == "" @echo off
+@rem ##########################################################################
+@rem
+@rem  Gradle startup script for Windows
+@rem
+@rem ##########################################################################
+
+@rem Set local scope for the variables with windows NT shell
+if "%OS%"=="Windows_NT" setlocal
+
+@rem Add default JVM options here. You can also use JAVA_OPTS and GRADLE_OPTS to pass JVM options to this script.
+set DEFAULT_JVM_OPTS="-Xmx64m" "-Xms64m"
+
+@rem Find java.exe
+if defined JAVA_HOME goto findJavaFromJavaHome
+
+set JAVA_EXE=java.exe
+%JAVA_EXE% -version >NUL 2>&1
+if "%ERRORLEVEL%" == "0" goto execute
+
+echo.
+echo ERROR: JAVA_HOME is not set and no 'java' command could be found in your PATH.
+echo.
+echo Please set the JAVA_HOME variable in your environment to match the
+echo location of your Java installation.
+
+goto fail
+
+:findJavaFromJavaHome
+set JAVA_EXE=%JAVA_HOME%\bin\java.exe
+
+if exist "%JAVA_EXE%" goto execute
+
+echo.
+echo ERROR: JAVA_HOME is set to an invalid directory: %JAVA_HOME%
+echo.
+echo Please set the JAVA_HOME variable in your environment to match the
+echo location of your Java installation.
+
+goto fail
+
+:execute
+@rem Setup the command line arguments.
+set CMD_LINE_ARGS=%*
+if "%CMD_LINE_ARGS%" == "" goto emptyArgs
+    set CMD_LINE_ARGS= %CMD_LINE_ARGS%
+:emptyArgs
+
+@rem Get the script directory
+set DIRNAME=%~dp0
+if "%DIRNAME%" == "" set DIRNAME=.
+set APP_BASE_NAME=%~n0
+set APP_HOME=%DIRNAME%
+
+@rem Add GRADLE_OPTS to CMD_LINE_ARGS
+set CMD_LINE_ARGS=%GRADLE_OPTS% %CMD_LINE_ARGS%
+
+@rem Split up SCRIPT_CMD into SCRIPT_CMD_PROGRAM and SCRIPT_CMD_ARGS
+set SCRIPT_CMD_PROGRAM="%JAVA_EXE%"
+set SCRIPT_CMD_ARGS=
+
+@rem Construct the classpath for the Gradle Wrapper
+set CLASSPATH=%APP_HOME%\gradle\wrapper\gradle-wrapper.jar
+
+@rem Execute Gradle
+%SCRIPT_CMD_PROGRAM% %DEFAULT_JVM_OPTS% %JAVA_OPTS% %GRADLE_OPTS% "-Dorg.gradle.appname=%APP_BASE_NAME%" -classpath "%CLASSPATH%" org.gradle.wrapper.GradleWrapperMain %CMD_LINE_ARGS%
+
+:end
+@rem End local scope for the variables with windows NT shell
+if "%ERRORLEVEL%"=="0" goto mainEnd
+
+:fail
+rem Set variable GRADLE_EXIT_CONSOLE if you need the _script_ return code instead of
+rem the _cmd.exe /c_ return code!
+if not "" == "%GRADLE_EXIT_CONSOLE%" (
+  exit 1
+) else (
+  exit /b 1
+)
+
+:mainEnd
+if "%OS%"=="Windows_NT" endlocal
+
+:omega


### PR DESCRIPTION
This commit introduces the Gradle Wrapper to ensure consistent builds and updates core build tool versions:

- Added `gradlew`, `gradlew.bat`, and `gradle/wrapper/gradle-wrapper.properties`. The wrapper is configured to use Gradle 8.2.
- Updated Android Gradle Plugin to 8.1.1.
- Updated Kotlin version to 1.9.10.
- Updated Jetpack Compose Compiler version to 1.5.3 (compatible with Kotlin 1.9.10).
- Updated `compileSdk` and `targetSdk` to 34.
- Updated various AndroidX and Compose dependencies to recent stable versions.

These changes bring the project up to date with modern Android development standards and improve build reliability.